### PR TITLE
Add CSV export option to plugin runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A modern memory forensics framework written in Rust, designed for analyzing memo
 - Extensible plugin architecture
 - Supports built-in and external plugins
 - Scan memory for various forensic artifacts
+- Export plugin findings to CSV
 
 ⚡ **Performance**
 - Fast memory mapping with minimal overhead
@@ -66,6 +67,9 @@ rmf extract-modules path/to/memory.dump output/dir
 ```bash
 # Run a specific plugin
 rmf run-plugin path/to/memory.dump string_carve
+
+# Run a plugin and export findings to CSV
+rmf run-plugin path/to/memory.dump string_carve --output findings.csv
 
 # List all available plugins
 rmf list-plugins

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ fn main() -> Result<()> {
             if let Some(out_path) = &output {
                 println!("Will export findings to: {}", out_path.display().to_string().bright_cyan());
             }
-            plugin::run_plugin(dump, plugin)?
+            plugin::run_plugin(dump, plugin, output)?
         },
         
         Commands::ListPlugins => {
@@ -211,7 +211,7 @@ fn main() -> Result<()> {
                 _ => "string_carve",  // Default to string carving
             };
             
-            plugin::run_plugin(dump, plugin_name.to_string())?
+            plugin::run_plugin(dump, plugin_name.to_string(), None)?
         },
         
         Commands::Translate { dump, address, dtb } => {


### PR DESCRIPTION
## Summary
- allow plugin results to be exported to CSV
- plumb optional output path from CLI into plugin runner
- document CSV export in README

## Testing
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6841e780c9f48321996f8803f4ae054d