### PR TITLE
Initialize plugin registry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,8 +139,10 @@ fn main() -> Result<()> {
     
     // Always enable colors
     colored::control::set_override(true);
-    
+
     loader::display_banner();
+    // Initialize built-in plugins so they are available for commands
+    plugin::init_plugins();
     let cli = Cli::parse();
     
     match cli.cmd {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -22,6 +22,15 @@ use prettytable::{Table, row, format};
 use std::path::PathBuf;
 use crate::loader::load_memory_image;
 
+/// Initialize built-in plugins and register them in the global registry
+pub fn init_plugins() {
+    let registry = get_plugin_registry();
+    let mut registry = registry.write().unwrap();
+
+    registry.register(Box::new(StringCarvePlugin::default()));
+    registry.register(Box::new(PEScanner));
+}
+
 /// Run a plugin by name on the provided memory dump
 pub fn run_plugin(dump_path: PathBuf, plugin_name: String) -> Result<()> {
     println!("{} {} {} {}",


### PR DESCRIPTION
## Summary
- register built-in plugins
- load plugins at startup so commands work

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6841e77f7a78832187ea517ee5b43be0